### PR TITLE
chore: add missing information to children modules

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -14,4 +14,26 @@
     <description>Commons for jchunk chunkers</description>
     <url>https://github.com/jchunk-io/jchunk</url>
     
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    
+    <developers>
+        <developer>
+            <name>Pablo Sanchidrian Herrera</name>
+            <url>https://github.com/PabloSanchi</url>
+        </developer>
+    </developers>
+    
+    <scm>
+        <connection>scm:git:https://github.com/jchunk-io/jchunk.git</connection>
+        <developerConnection>scm:git:https://github.com/jchunk-io/jchunk.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/jchunk-io/jchunk</url>
+    </scm>
+    
 </project>

--- a/jchunk-core/pom.xml
+++ b/jchunk-core/pom.xml
@@ -14,4 +14,26 @@
     <description>Base definitions for jchunk module</description>
     <url>https://github.com/jchunk-io/jchunk</url>
     
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    
+    <developers>
+        <developer>
+            <name>Pablo Sanchidrian Herrera</name>
+            <url>https://github.com/PabloSanchi</url>
+        </developer>
+    </developers>
+    
+    <scm>
+        <connection>scm:git:https://github.com/jchunk-io/jchunk.git</connection>
+        <developerConnection>scm:git:https://github.com/jchunk-io/jchunk.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/jchunk-io/jchunk</url>
+    </scm>
+    
 </project>

--- a/jchunk-fixed/pom.xml
+++ b/jchunk-fixed/pom.xml
@@ -14,6 +14,28 @@
     <description>Fixed Chunker for Java</description>
     <url>https://github.com/jchunk-io/jchunk</url>
     
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    
+    <developers>
+        <developer>
+            <name>Pablo Sanchidrian Herrera</name>
+            <url>https://github.com/PabloSanchi</url>
+        </developer>
+    </developers>
+    
+    <scm>
+        <connection>scm:git:https://github.com/jchunk-io/jchunk.git</connection>
+        <developerConnection>scm:git:https://github.com/jchunk-io/jchunk.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/jchunk-io/jchunk</url>
+    </scm>
+    
     <dependencies>
         <dependency>
             <groupId>io.jchunk</groupId>

--- a/jchunk-recursive-character/pom.xml
+++ b/jchunk-recursive-character/pom.xml
@@ -14,6 +14,28 @@
     <description>Recursive Character Chunker for Java</description>
     <url>https://github.com/jchunk-io/jchunk</url>
     
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    
+    <developers>
+        <developer>
+            <name>Pablo Sanchidrian Herrera</name>
+            <url>https://github.com/PabloSanchi</url>
+        </developer>
+    </developers>
+    
+    <scm>
+        <connection>scm:git:https://github.com/jchunk-io/jchunk.git</connection>
+        <developerConnection>scm:git:https://github.com/jchunk-io/jchunk.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/jchunk-io/jchunk</url>
+    </scm>
+    
     <dependencies>
         <dependency>
             <groupId>io.jchunk</groupId>

--- a/jchunk-semantic/pom.xml
+++ b/jchunk-semantic/pom.xml
@@ -9,11 +9,33 @@
     
     <artifactId>jchunk-semantic</artifactId>
     <packaging>jar</packaging>
-
+    
     <name>JChunk - Semantic Chunker</name>
     <description>Semantic Chunker for Java</description>
     <url>https://github.com/jchunk-io/jchunk</url>
-
+    
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    
+    <developers>
+        <developer>
+            <name>Pablo Sanchidrian Herrera</name>
+            <url>https://github.com/PabloSanchi</url>
+        </developer>
+    </developers>
+    
+    <scm>
+        <connection>scm:git:https://github.com/jchunk-io/jchunk.git</connection>
+        <developerConnection>scm:git:https://github.com/jchunk-io/jchunk.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/jchunk-io/jchunk</url>
+    </scm>
+    
     <properties>
         <onnxruntime.version>1.22.0</onnxruntime.version>
         <djl.version>0.34.0</djl.version>


### PR DESCRIPTION
### Description (must)

Add `SCM`, `LICENSE` and `DEVELOPERS` info to modules
